### PR TITLE
Add nuget-publish-skill Claude Code plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "enabledPlugins": {
+    "nuget-publish-skill@kudima03": true
+  },
+  "extraKnownMarketplaces": {
+    "kudima03": {
+      "source": {
+        "source": "github",
+        "repo": "kudima03/claude-plugins"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #47

Adds `.claude/settings.json` to install the `nuget-publish-skill@kudima03` plugin.