### PR TITLE
Fix release state for 0.1.0-preview.4.1.0 (baseline + suppressions)

### DIFF
--- a/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/CompatibilitySuppressions.xml
+++ b/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/CompatibilitySuppressions.xml
@@ -1,3 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+<Suppressions
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+/>

--- a/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/CompatibilitySuppressions.xml
+++ b/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/CompatibilitySuppressions.xml
@@ -1,32 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0003</DiagnosticId>
-    <Target>Pure.Chart.RichRelationalModel.EFCore.Models.Configurations, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null</Target>
-    <Left>lib/net10.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Left>
-    <Right>lib/net10.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0003</DiagnosticId>
-    <Target>Pure.Chart.RichRelationalModel.EFCore.Models.Configurations, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null</Target>
-    <Left>lib/net7.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Left>
-    <Right>lib/net7.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0003</DiagnosticId>
-    <Target>Pure.Chart.RichRelationalModel.EFCore.Models.Configurations, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null</Target>
-    <Left>lib/net8.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Left>
-    <Right>lib/net8.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0003</DiagnosticId>
-    <Target>Pure.Chart.RichRelationalModel.EFCore.Models.Configurations, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null</Target>
-    <Left>lib/net9.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Left>
-    <Right>lib/net9.0/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-</Suppressions>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />

--- a/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.csproj
+++ b/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.4.1.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.4.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Chart.RichRelationalModel.EFCore.Models.Configurations</PackageId>


### PR DESCRIPTION
The `0.1.0-preview.4.1.0` publish [previously failed](https://github.com/kudima03/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/actions/runs/27090818749/job/79954004211) and left `main` in a state where the tag build cannot pass. This PR fixes it before re-tagging.

## Problems
1. **Baseline points to an unpublished version.** `PackageValidationBaselineVersion` was bumped to `0.1.0-preview.4.1.0` (#50), but that version was never published. `dotnet restore`/`pack` fails with `NU1102: Unable to find package ... 4.1.0`.
2. **Unnecessary suppressions.** The CP0003 assembly-version suppressions added in #49 are not needed against the `4.0.0` baseline, producing `error: Unnecessary suppressions found` (the original cause of the failed publish).

## Changes
- `PackageValidationBaselineVersion`: `0.1.0-preview.4.1.0` → `0.1.0-preview.4.0.0` (last published version)
- `CompatibilitySuppressions.xml`: emptied (regenerated against the `4.0.0` baseline yields zero suppressions)

Verified locally: `dotnet pack -p:PackageVersion=0.1.0-preview.4.1.0` now succeeds with no compat errors. After this merges, the `0.1.0-preview.4.1.0` tag will be pushed, and the baseline bumped to `4.1.0` in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)