### PR TITLE
Update package validation baseline to 0.1.0-preview.4.1.1

### DIFF
--- a/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.csproj
+++ b/src/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations/Pure.Chart.RichRelationalModel.EFCore.Models.Configurations.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.4.1.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.4.1.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Chart.RichRelationalModel.EFCore.Models.Configurations</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.4.1.0` to `0.1.0-preview.4.1.1` following the successful publish.